### PR TITLE
fix: added hint code error message

### DIFF
--- a/app/components/HintList/HintList.tsx
+++ b/app/components/HintList/HintList.tsx
@@ -40,7 +40,6 @@ function HintList() {
     setIsModifyEnableds(enableds);
   };
 
-
   const handleCreateHint = useCallback(() => {
     if (activeHint.isOpen) {
       setDialogOpen(true);

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useRef, useState } from "react";
-import { usePostHint } from "@/mutations/postHint";
 import { SubmitHandler, useForm } from "react-hook-form";
+
+import { usePostHint } from "@/mutations/postHint";
 import { usePutHint } from "@/mutations/putHint";
+
 import { useSelectedThemeValue } from "../atoms/selectedTheme.atom";
-import HintManagerView from "./HintManagerView";
 import {
   useIsActiveHintItemState,
   useIsOpenDeleteDialogStateWrite,
 } from "../atoms/hints.atom";
+
+import HintManagerView from "./HintManagerView";
 import Dialog from "../common/Dialog/Dialog";
 
 const MAKE = "make";
@@ -48,8 +51,11 @@ function HintManager(props: Props) {
   const { mutateAsync: postHint, isSuccess: postHintSuccess } = usePostHint();
   const { mutateAsync: putHint } = usePutHint();
   const { id: themeId } = useSelectedThemeValue();
-  const setIsOpenDeleteDialogState = useIsOpenDeleteDialogStateWrite();
   const formRef = useRef<HTMLFormElement>(null);
+
+  const setIsOpenDeleteDialogState = useIsOpenDeleteDialogStateWrite();
+
+  const [errorMsg, setErrorMsg] = useState<string>("");
   const [isActiveHintItemState, setIsActiveHintItemState] =
     useIsActiveHintItemState();
 
@@ -224,10 +230,18 @@ function HintManager(props: Props) {
     helperText: errors?.hintCode && errors?.hintCode.message,
     type: "number",
     onClick: activateForm,
+
     ...register("hintCode", {
       pattern: {
         value: /^\d{4}$/,
         message: "4자리 숫자만 입력 가능합니다.",
+      },
+      onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
+        if (e.target.value.length !== 4) {
+          setErrorMsg("힌트 코드는 4자리 숫자만 입력 가능합니다.");
+        } else {
+          setErrorMsg("");
+        }
       },
     }),
   };
@@ -281,6 +295,7 @@ function HintManager(props: Props) {
     makeHintButtonProps,
     isCurrentHintActive,
     wrapperProps,
+    errorMsg,
   };
 
   return (

--- a/app/components/HintManager/HintManagerView.styled.ts
+++ b/app/components/HintManager/HintManagerView.styled.ts
@@ -22,6 +22,7 @@ export const StyledBox = styled(Box)<{ active?: boolean }>`
 export const Wrapper = styled.div<{ selected?: boolean }>`
   width: 100%;
   padding: 8px;
+  position: relative;
   box-sizing: border-box;
   background-color: ${({ theme }) => theme.color.white10};
 
@@ -71,4 +72,14 @@ export const FunctionButtonsWrapper = styled.div`
   justify-content: end;
   align-items: end;
   gap: 8px;
+`;
+
+export const ErrorMsgWrapper = styled.div`
+  position: absolute;
+  color: red;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  text-align: right;
+  left: 15px;
 `;

--- a/app/components/HintManager/HintManagerView.tsx
+++ b/app/components/HintManager/HintManagerView.tsx
@@ -4,6 +4,7 @@ import { Button, Input } from "@mui/material";
 import * as S from "./HintManagerView.styled";
 
 interface Props {
+  errorMsg: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   progressInputProps: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,6 +37,7 @@ function HintManagerView(props: Props) {
     formProps,
     isCurrentHintActive,
     wrapperProps,
+    errorMsg,
   } = props;
 
   return (
@@ -47,6 +49,7 @@ function HintManagerView(props: Props) {
           <Input className="TextareaBox" {...contentsInputProps} />
           <Input className="TextareaBox" {...answerInputProps} />
         </S.InputsWrapper>
+        <S.ErrorMsgWrapper>{errorMsg}</S.ErrorMsgWrapper>
         <S.FunctionButtonsWrapper {...wrapperProps}>
           <Button {...deleteButtonProps}>{DELETE}</Button>
           <Button {...makeHintButtonProps}>{MAKE_HINT}</Button>


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 힌트코드가 4자리가 안된 상태에서 input 창 포커스 아웃될 때 에러 메시지를 보여주도록 수정

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
