### PR TITLE
fix: Disable Clarity script on admin page

### DIFF
--- a/app/apis/Clarity.tsx
+++ b/app/apis/Clarity.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import Script from "next/script";
+import { usePathname } from "next/navigation";
 
 function Clarity() {
+  const pathname = usePathname();
+
+  if (pathname === "/admin") return null;
+
   const clarityScript = `
   (function(c,l,a,r,i,t,y){
     c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- admin에서도 Clarity 정보 수집되고 있는 부분 스크립트 실행되지 않도록 수정했습니다.

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- Clarity.tsx 파일에 router 조건문 추가

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
