### PR TITLE
feat: add new textfield

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,16 +20,17 @@
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
-    "project": [
-      "tsconfig.json"
-    ]
+    "project": ["tsconfig.json"]
   },
-  "plugins": [
-    "react",
-    "@typescript-eslint"
-  ],
+  "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "react/jsx-props-no-spreading": "off"
+    "react/jsx-props-no-spreading": "off",
+    "jsx-a11y/label-has-associated-control": [
+      2,
+      {
+        "labelAttributes": ["htmlFor"]
+      }
+    ]
   }
 }

--- a/stories/NewTextField.component.tsx
+++ b/stories/NewTextField.component.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import "../app/style/reset.css";
+import styled from "styled-components";
+
+interface SupportingTextProps {
+  error: boolean;
+}
+
+export interface TextFieldProps {
+  label: string;
+  disabled: boolean;
+  error: boolean;
+  placeholder: string;
+  helperText: string;
+}
+
+const Label = styled.label`
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  font-size: 12px;
+  line-height: 16px;
+`;
+
+const LabelOnly = styled.label`
+  position: absolute;
+  margin: 30px 22px;
+  font-size: 16px;
+  line-height: 22px;
+`;
+
+const Input = styled.input`
+  height: 18px;
+  margin: 40px 20px 20px 20px;
+  font-size: 16px;
+  color: white;
+  line-height: 22px;
+  background-color: transparent;
+  &:focus {
+    outline: none;
+  }
+`;
+
+const Div = styled.div<SupportingTextProps>`
+  display: flex;
+  /* border: 1px solid #474547; */
+  border: 1px solid ${({ error }) => (error ? "#f2b8b5" : "#89888a")};
+
+  width: 368px;
+  position: relative;
+  background: #121212;
+  border-radius: 8px;
+  gap: 4px;
+  flex-direction: column;
+  &:focus-within {
+    border: 1px solid ${({ error }) => (error ? "#f2b8b5" : "white")};
+  }
+
+  &:hover {
+    background-color: black;
+  }
+
+  &:disabled {
+    border: #474547;
+  }
+  label {
+    color: ${({ error }) => (error ? "#f2b8b5" : "#89888a")};
+  }
+`;
+const SupportingText = styled.p<SupportingTextProps>`
+  color: ${({ error }) => (error ? "#f2b8b5" : "#89888a")};
+  font-size: 12px;
+  line-height: 16px;
+  margin: 4px 16px;
+`;
+
+export function NewTextField({
+  label = "제목",
+  disabled = false,
+  error = false,
+  placeholder = "미리보기",
+  helperText = "Supporting text",
+}: TextFieldProps) {
+  return (
+    <div>
+      <Div error={error}>
+        <Label htmlFor="textField">{label}</Label>
+        <Input id="textField" disabled={disabled} placeholder={placeholder} />
+      </Div>
+      <SupportingText error={error}>{helperText}</SupportingText>
+    </div>
+  );
+}
+
+export function NewTextFieldLabel({
+  label = "제목",
+  disabled = false,
+  error = false,
+  placeholder = "",
+  helperText = "Supporting text",
+}: TextFieldProps) {
+  return (
+    <div>
+      <Div error={error}>
+        <LabelOnly htmlFor="textField">{label}</LabelOnly>
+        <Input id="textField" disabled={disabled} placeholder={placeholder} />
+      </Div>
+      <SupportingText error={error}>{helperText}</SupportingText>
+    </div>
+  );
+}

--- a/stories/NewTextField.stories.tsx
+++ b/stories/NewTextField.stories.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import Stack from "@mui/material/Stack";
+import {
+  NewTextField,
+  TextFieldProps,
+  NewTextFieldLabel,
+} from "./NewTextField.component";
+
+export default {
+  title: "Component/NewTextField",
+  component: NewTextField,
+  argTypes: {
+    disabled: { control: "boolean" },
+    error: { control: "boolean" },
+    placeholder: { control: "text" },
+  },
+};
+
+export const Playground = {
+  args: {
+    label: "Click me!",
+  },
+  render: (args: TextFieldProps) => <NewTextField {...args} />,
+};
+export const LabelAndInput = {
+  render: (args: TextFieldProps) => (
+    <Stack spacing={2} maxWidth={300}>
+      <NewTextField {...args} />
+    </Stack>
+  ),
+};
+
+export const LabelOnly = {
+  render: (args: TextFieldProps) => <NewTextFieldLabel {...args} />,
+};


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 스토리북에 새로운 텍스트필드를 추가했어요

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 스토리북 NewTextField.component , NewTextField.stories 

### 💡 필요한 후속작업이 있어요.

-  라벨만 있는 텍스트 필드에서 클릭시 내용을 입력하는 액션 추가
- QA필요

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
