### PR TITLE
fix: dashboard QA

### DIFF
--- a/app/components/HintItem/HintItemView.tsx
+++ b/app/components/HintItem/HintItemView.tsx
@@ -16,7 +16,7 @@ function HintItemView(props: Props) {
   return (
     <S.ItemWrapper key={id} onClick={onClick}>
       <div className="numberBox">{hintData.hintCode}</div>
-      <div className="numberBox">{hintData.progress}</div>
+      <div className="numberBox">{hintData.progress}%</div>
       <div className="textBox">
         <span>{hintData.contents}</span>
       </div>

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -236,6 +236,7 @@ function HintManager(props: Props) {
         setErrorMsg("");
       }
     },
+    endAdornment: <>%</>,
   };
 
   const hintCodeInputProps = {

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
@@ -127,7 +128,7 @@ function HintManager(props: Props) {
 
   const key = `${type}-${id}`;
 
-  const onSubmit: SubmitHandler<FormValues> = (data) => {
+  const onSubmit: SubmitHandler<FormValues> = _.debounce((data) => {
     const { progress, hintCode, contents, answer } = data;
 
     if (!(progress && hintCode && contents && answer)) {
@@ -156,7 +157,7 @@ function HintManager(props: Props) {
     }
     reset();
     close();
-  };
+  }, 300);
 
   const isCurrentHintActive = isActiveHintItemState === id;
 

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -100,6 +100,12 @@ function HintManager(props: Props) {
     return () => subscription.unsubscribe();
   }, [hintData, watch]);
 
+  useEffect(() => {
+    if (!open) {
+      setErrorMsg("");
+    }
+  }, [open, reset]);
+
   const formValue = watch();
   useEffect(() => {
     if (
@@ -223,6 +229,13 @@ function HintManager(props: Props) {
         message: "1부터 100까지의 정수만 입력 가능합니다.",
       },
     }),
+    onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
+      if (!/^(100|[1-9][0-9]?|0)$/.test(e.target.value)) {
+        setErrorMsg("1부터 100까지의 정수만 입력 가능합니다.");
+      } else {
+        setErrorMsg("");
+      }
+    },
   };
 
   const hintCodeInputProps = {
@@ -237,7 +250,7 @@ function HintManager(props: Props) {
         message: "4자리 숫자만 입력 가능합니다.",
       },
       onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
-        if (e.target.value.length !== 4) {
+        if (!/^\d{4}$/.test(e.target.value)) {
           setErrorMsg("힌트 코드는 4자리 숫자만 입력 가능합니다.");
         } else {
           setErrorMsg("");

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -111,8 +111,8 @@ function HintManager(props: Props) {
     if (
       !formValue.progress ||
       !(formValue.hintCode.length === 4) ||
-      !formValue.contents ||
-      !formValue.answer
+      !formValue.contents.trim() ||
+      !formValue.answer.trim()
     ) {
       setSubmitDisable(true);
     } else {

--- a/app/components/MakeThemePage/MakeThemePage.tsx
+++ b/app/components/MakeThemePage/MakeThemePage.tsx
@@ -96,7 +96,13 @@ function MakeThemePage() {
     label: "테마 이름",
     placeholder: "입력해 주세요.",
     message: "손님에게는 보이지 않아요.",
-    ...register("title", { required: "테마 이름은 필수 값 입니다" }),
+    ...register("title", {
+      required: "테마 이름은 필수값입니다",
+      pattern: {
+        value: /^\S+$/,
+        message: "테마 이름은 필수값입니다",
+      },
+    }),
   };
   const timeLimitProps = {
     id: "timeLimit",

--- a/app/components/MakeThemePage/MakeThemePage.tsx
+++ b/app/components/MakeThemePage/MakeThemePage.tsx
@@ -7,6 +7,7 @@ import { usePutTheme } from "@/mutations/putTheme";
 import { useSelectedTheme } from "@/components/atoms/selectedTheme.atom";
 import { useModalState } from "@/components/atoms/modals.atom";
 import { useRouter } from "next/navigation";
+import { useGetThemeList } from "@/queries/getThemeList";
 import MakeThemeModalView from "./MakeThemePageView";
 import Dialog from "../common/Dialog/Dialog";
 
@@ -19,6 +20,7 @@ interface FormValues {
 
 function MakeThemePage() {
   const [modalState, setModalState] = useModalState();
+  const { data: categories = [] } = useGetThemeList();
   const [open, setOpen] = useState<boolean>(false);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -37,21 +39,15 @@ function MakeThemePage() {
 
   const formValue = watch();
   const handleClose = () => {
-    if (
-      selectedTheme.title === formValue.title &&
-      selectedTheme.timeLimit === formValue.timeLimit &&
-      selectedTheme.hintLimit === formValue.hintLimit
-    ) {
-      setModalState({ ...modalState, isOpen: false });
-    }
+    setSelectedTheme(categories[categories.length - 1]);
     if (
       modalState.type === "post" &&
       !(formValue.title || formValue.timeLimit || formValue.hintLimit)
     ) {
       setModalState({ ...modalState, isOpen: false });
+    } else {
+      setOpen(!open);
     }
-
-    setOpen(!open);
   };
   useEffect(() => {
     reset();

--- a/app/components/MakeThemePage/MakeThemePage.tsx
+++ b/app/components/MakeThemePage/MakeThemePage.tsx
@@ -31,6 +31,7 @@ function MakeThemePage() {
     setValue,
     watch,
     reset,
+
     formState: { errors },
   } = useForm<FormValues>();
 
@@ -118,13 +119,14 @@ function MakeThemePage() {
       },
     }),
   };
+
   const hintLimitProps = {
     id: "hintLimit",
     label: "힌트 개수",
     type: "number",
     message: "이 테마에서 사용할 수 있는 힌트 수를 입력해 주세요.",
     ...register("hintLimit", {
-      required: "힌트 수를 입력해 주세요..",
+      required: "힌트 수를 입력해 주세요.",
       pattern: {
         value: /^[1-9]\d*$/,
         message: "1개 이상으로 입력해 주세요.",

--- a/app/components/MakeThemePage/MakeThemePage.tsx
+++ b/app/components/MakeThemePage/MakeThemePage.tsx
@@ -102,7 +102,7 @@ function MakeThemePage() {
     ...register("title", {
       required: "테마 이름은 필수값입니다",
       pattern: {
-        value: /^\S+$/,
+        value: /^.+$/,
         message: "테마 이름은 필수값입니다",
       },
     }),

--- a/app/components/MakeThemePage/MakeThemePage.tsx
+++ b/app/components/MakeThemePage/MakeThemePage.tsx
@@ -31,8 +31,8 @@ function MakeThemePage() {
     setValue,
     watch,
     reset,
-
     formState: { errors },
+    trigger,
   } = useForm<FormValues>();
 
   const formValue = watch();
@@ -61,6 +61,12 @@ function MakeThemePage() {
       setValue("hintLimit", selectedTheme.hintLimit);
     }
   }, [selectedTheme, setValue, modalState.type, reset]);
+
+  useEffect(() => {
+    if (formValue.title && formValue.timeLimit && formValue.hintLimit) {
+      trigger();
+    }
+  }, [formValue.hintLimit, formValue.timeLimit, formValue.title, trigger]);
 
   const { mutateAsync: postTheme } = usePostTheme();
   const { mutateAsync: putTheme } = usePutTheme();

--- a/app/components/MakeThemePage/MakeThemePageView.tsx
+++ b/app/components/MakeThemePage/MakeThemePageView.tsx
@@ -21,7 +21,9 @@ type Props = {
   formProps: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   timeLimitProps: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   themeNameProps: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   hintLimitProps: Record<string, any>;
   titleError: FieldError | undefined;
   timeLimitError: FieldError | undefined;

--- a/app/components/ThemeDetail/ThemeDetail.styled.ts
+++ b/app/components/ThemeDetail/ThemeDetail.styled.ts
@@ -8,8 +8,11 @@ export const Wrapper = styled(Box)`
 `;
 
 export const Title = styled.div`
+  width: 100%;
   font-size: ${(props) => props.theme.fontSize.lg};
   font-weight: ${(props) => props.theme.fontWeight.bold};
+  white-space: pre-wrap;
+  word-break: break-word;
 `;
 
 export const MiddleTitle = styled.div`

--- a/app/components/atoms/selectedTheme.atom.ts
+++ b/app/components/atoms/selectedTheme.atom.ts
@@ -12,9 +12,16 @@ interface SelectedTheme {
   hintLimit: number;
 }
 
+export const InitialSelectedTheme: SelectedTheme = {
+  id: 0,
+  title: "",
+  timeLimit: 0,
+  hintLimit: 0,
+} as const;
+
 const selectedThemeState = atom<SelectedTheme>({
   key: "selectedTheme",
-  default: { id: 0, title: "", timeLimit: 0, hintLimit: 0 },
+  default: InitialSelectedTheme,
 });
 
 export const useSelectedTheme = () => useRecoilState(selectedThemeState);

--- a/app/components/common/Dialog/Dialog.tsx
+++ b/app/components/common/Dialog/Dialog.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect } from "react";
 import DialogView from "./DialogView";
 
 type ContentType = "hintPut" | "themePut" | "hintPost" | "themePost";
@@ -12,10 +13,24 @@ interface Props {
 function Dialog(props: Props) {
   const { open, handleDialogClose, type, handleBtn } = props;
 
-  const handleQuitDialog = () => {
+  const handleQuitDialog = useCallback(() => {
     handleBtn();
     handleDialogClose();
-  };
+  }, [handleBtn, handleDialogClose]);
+
+  useEffect(() => {
+    const handleEnterKey = (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        handleQuitDialog();
+      }
+    };
+
+    document.addEventListener("keydown", handleEnterKey);
+
+    return () => {
+      document.removeEventListener("keydown", handleEnterKey);
+    };
+  }, [handleQuitDialog]);
 
   // 힌트 함수 추가
 

--- a/app/components/common/Drawer/Drawer.tsx
+++ b/app/components/common/Drawer/Drawer.tsx
@@ -12,7 +12,10 @@ import { useRouter } from "next/navigation";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import AddIcon from "@mui/icons-material/Add";
 import { useModalState } from "@/components/atoms/modals.atom";
-import { useSelectedThemeWrite } from "@/components/atoms/selectedTheme.atom";
+import {
+  InitialSelectedTheme,
+  useSelectedTheme,
+} from "@/components/atoms/selectedTheme.atom";
 import { Theme, Themes } from "@/queries/getThemeList";
 import Image from "next/image";
 import { getShopName } from "@/utils/localStorage";
@@ -35,18 +38,17 @@ function MainDrawer(props: Props) {
   const { categories } = props;
   const router = useRouter();
 
-  const setSelectedTheme = useSelectedThemeWrite();
+  const [selectedTheme, setSelectedTheme] = useSelectedTheme();
   const shopName = getShopName();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [modalState, setModalState] = useModalState();
   const [focusedTheme, setFocusedTheme] = useState<Theme | null>(null); // 현재 선택된 테마를 저장할 상태 추가
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [open, setOpen] = useState<boolean>(false);
 
   const toggleOnModalState = () => {
     router.push("/theme");
-    setSelectedIndex(null);
+    setSelectedTheme(InitialSelectedTheme);
 
     setModalState({ type: "post", isOpen: true });
   };
@@ -57,18 +59,15 @@ function MainDrawer(props: Props) {
 
   useEffect(() => {
     if (categories.length > 0) {
-      setSelectedIndex(categories[categories.length - 1].id);
       setSelectedTheme(categories[categories.length - 1]);
     }
   }, [categories, setSelectedTheme]);
 
   const handleListItemClick = (theme: Theme) => {
     setFocusedTheme(theme);
-    // setSelectedTheme({ ...theme });
     if (modalState.isOpen) {
       handleDialog();
     } else {
-      setSelectedIndex(theme.id);
       setSelectedTheme({ ...theme });
       router.push(`/admin?title=${encodeURIComponent(theme.title)}`);
     }
@@ -93,7 +92,7 @@ function MainDrawer(props: Props) {
         {[...categories].reverse().map((theme) => (
           <ListItem key={theme.id}>
             <ListItemButton
-              selected={selectedIndex === theme.id}
+              selected={selectedTheme.id === theme.id}
               onClick={() => {
                 handleListItemClick(theme);
               }}
@@ -122,7 +121,6 @@ function MainDrawer(props: Props) {
         handleBtn={() => {
           if (focusedTheme) {
             setModalState({ ...modalState, isOpen: false });
-            setSelectedIndex(focusedTheme.id);
             setSelectedTheme({ ...focusedTheme });
             router.push(
               `/admin?title=${encodeURIComponent(focusedTheme.title)}`

--- a/app/components/common/Drawer/Drawer.tsx
+++ b/app/components/common/Drawer/Drawer.tsx
@@ -90,14 +90,22 @@ function MainDrawer(props: Props) {
         </S.ShopNameListItem>
 
         {[...categories].reverse().map((theme) => (
-          <ListItem key={theme.id}>
+          <ListItem key={theme.id} title={theme.title}>
             <ListItemButton
               selected={selectedTheme.id === theme.id}
               onClick={() => {
                 handleListItemClick(theme);
               }}
             >
-              <ListItemText>{theme.title}</ListItemText>
+              <ListItemText
+                style={{
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {theme.title}
+              </ListItemText>
             </ListItemButton>
           </ListItem>
         ))}

--- a/app/components/common/Drawer/Drawer.tsx
+++ b/app/components/common/Drawer/Drawer.tsx
@@ -24,35 +24,37 @@ type Props = {
   categories: Themes;
 };
 
+const logoProps = {
+  src: "/images/svg/logo.svg",
+  alt: "NEXT ROOM",
+  width: 184,
+  height: 26,
+};
+
 function MainDrawer(props: Props) {
   const { categories } = props;
   const router = useRouter();
 
   const setSelectedTheme = useSelectedThemeWrite();
-  // const { mutateAsync: deleteTheme } = useDeleteTheme();
   const shopName = getShopName();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [modalState, setModalState] = useModalState();
+  const [focusedTheme, setFocusedTheme] = useState<Theme | null>(null); // 현재 선택된 테마를 저장할 상태 추가
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [open, setOpen] = useState<boolean>(false);
+
   const toggleOnModalState = () => {
     router.push("/theme");
+    setSelectedIndex(null);
 
     setModalState({ type: "post", isOpen: true });
   };
-  const logoProps = {
-    src: "/images/svg/logo.svg",
-    alt: "NEXT ROOM",
-    width: 184,
-    height: 26,
-  };
-  const [focusedTheme, setFocusedTheme] = useState<Theme | null>(null); // 현재 선택된 테마를 저장할 상태 추가
-
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [open, setOpen] = useState<boolean>(false);
 
   const handleDialog = () => {
     setOpen(!open);
   };
+
   useEffect(() => {
     if (categories.length > 0) {
       setSelectedIndex(categories[categories.length - 1].id);
@@ -89,7 +91,7 @@ function MainDrawer(props: Props) {
         </S.ShopNameListItem>
 
         {[...categories].reverse().map((theme) => (
-          <ListItem>
+          <ListItem key={theme.id}>
             <ListItemButton
               selected={selectedIndex === theme.id}
               onClick={() => {
@@ -99,7 +101,6 @@ function MainDrawer(props: Props) {
               <ListItemText>{theme.title}</ListItemText>
             </ListItemButton>
           </ListItem>
-          // </Link>
         ))}
         <ListItem
           style={{

--- a/app/home/HomeView.styled.ts
+++ b/app/home/HomeView.styled.ts
@@ -4,6 +4,7 @@ import { MAIN_GRID_WIDTH } from "@/consts/styles/common";
 
 export const Wrapper = styled(Box)`
   display: flex;
+  min-width: 1280px;
   height: 100vh;
   overflow: hidden;
 `;

--- a/app/queries/getThemeList.ts
+++ b/app/queries/getThemeList.ts
@@ -19,6 +19,7 @@ type Response = ApiResponse<Themes>;
 
 const URL_PATH = `/v1/theme`;
 export const QUERY_KEY = [URL_PATH];
+// TODO - 유저 id를 키에 추가해야 함
 
 export const getThemeList = async (config?: AxiosRequestConfig) => {
   const res = await apiClient.get<Request, AxiosResponse<Response>>(URL_PATH, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-config-next": "13.4.7",
         "firebase": "^10.6.0",
         "framer-motion": "^10.16.4",
+        "lodash": "^4.17.21",
         "next": "13.4.7",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -15407,7 +15408,7 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-config-next": "13.4.7",
     "firebase": "^10.6.0",
     "framer-motion": "^10.16.4",
+    "lodash": "^4.17.21",
     "next": "13.4.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 대시보드 QA
- 소수점 입력 가능하도록
- 테마 이름에 공백만 넣었을 때 에러 추가
- 숫자폼에서 숫자만 입력되도록 변경
- 입력폼 완성되지 않았을 때 메시지 출력
- 테마 추가하기 접근했을 때 focus 해제하기
- ESC, Enter 키 지원

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- Debounce의 쉬운 구현을 위해서 lodash 라이브러리 설치했습니당

<br><br>


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
