### PR TITLE
fix: 401 에러시 바로 로그아웃 처리되지 않는 이슈 수정

### DIFF
--- a/app/lib/reactQueryProvider.tsx
+++ b/app/lib/reactQueryProvider.tsx
@@ -4,7 +4,6 @@ import { PropsWithChildren, useState } from "react";
 import axios from "axios";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { useRouter } from "next/navigation";
 
 import {
   getLoginInfo,
@@ -94,8 +93,7 @@ apiClient.interceptors.response.use(
           processQueue(refreshError, null);
           removeLocalStorageAll();
           if (typeof window !== "undefined") {
-            const router = useRouter();
-            router.push("/login");
+            window.location.href = "/login";
           }
           throw refreshError;
         } finally {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

-  Axios 인터셉터는 Next에서 순수 자바스크립트로 실행돼서 useRouter 가 실행이 바로 안돼서 login 화면으로 안넘어감
- window.location.href를 사용해서 강제로 이동하도록 함

<br><br>



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
