### PR TITLE
fix: 회원가입 401에러 예외처리

### DIFF
--- a/app/lib/reactQueryProvider.tsx
+++ b/app/lib/reactQueryProvider.tsx
@@ -90,11 +90,15 @@ apiClient.interceptors.response.use(
           processQueue(null, response.accessToken);
           return apiClient(originalRequest);
         } catch (refreshError) {
-          processQueue(refreshError, null);
-          removeLocalStorageAll();
           if (typeof window !== "undefined") {
-            window.location.href = "/login";
+            const currentPath = window.location.pathname;
+            if (currentPath !== "/signup") {
+              processQueue(refreshError, null);
+              removeLocalStorageAll();
+              window.location.href = "/login";
+            }
           }
+
           throw refreshError;
         } finally {
           isRefreshing = false;


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 회원가입 이메일 인증코드 불일치하는 경우 예외로 로그인 페이지로 리다이렉트되지 않도록 함
- #96 
<br><br>


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
