### PR TITLE
fix: 구글 로그인 코드 파싱 로직 수정

### DIFF
--- a/app/signup/apis/getGoogleCallback.ts
+++ b/app/signup/apis/getGoogleCallback.ts
@@ -47,6 +47,7 @@ export const useGetGoogleCallbackData = (code: string) => {
   const { data, isLoading } = useQuery<Response, AxiosError, data>({
     queryKey: [`google-callback-${code}`],
     queryFn: () => getGoogleCallback(code),
+    enabled: !!code,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     select: (res) => res.data,

--- a/app/signup/components/SignUpWithGoogle.tsx
+++ b/app/signup/components/SignUpWithGoogle.tsx
@@ -16,14 +16,15 @@ import { SignUpDropDownField } from "./SignUpDropDownField";
 const SignUpWithGoogleComponent = ({ query }: { query: string }) => {
   const router = useRouter();
 
-  const decodedCode = decodeURIComponent(query.split("&")[0].slice(6));
-  if (decodedCode === "=access_denied") {
+  const params = new URLSearchParams(query);
+  const code = params.get("code") ?? "";
+  const errorParam = params.get("error");
+  if (errorParam === "access_denied") {
     window.alert("권한이 없습니다. 로그인 페이지로 이동합니다.");
     router.push("/login");
   }
 
-  const { data: callbackData, isLoading } =
-    useGetGoogleCallbackData(decodedCode);
+  const { data: callbackData, isLoading } = useGetGoogleCallbackData(code);
 
   const [isRedirecting, setIsRedirecting] = useState(false);
   useEffect(() => {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

구글 OAuth가 끝나면 구글이 /signup으로 리다이렉트하면서 인가 코드(code)를 쿼리 파라미터로 붙여줌

그 code를 백엔드(/v1/auth/login/google/callback)로 보내야 로그인이 완료되는데, 이전 로직에서 code 값을 잘못 잘라내고 있었음

```
const decodedCode = decodeURIComponent(query.split("&")[0].slice(6));
```

이게 문제가 됐던 코드인데

이 코드는 "쿼리스트링의 첫 번째 파라미터는 무조건 ?code= 이다" 라고 가정하고 돌아가는 코드임

아마 예전에는 이게 동작했던거로 보임. 근데 어느 순간부터 구글에서 code가 아닌 다른 값을 맨 앞에 붙여서 보내기 시작했고(= 스펙 변경) 그때부터 구글 로그인이 먹통이 된거임

```
http://localhost:3000/signup?iss=...&code=...&...
```

이런식으로 iss라는게 추가가 됨

<br><br>


<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

```
  const params = new URLSearchParams(query);
  const code = params.get("code") ?? "";
  const errorParam = params.get("error");
  if (errorParam === "access_denied") {
    window.alert("권한이 없습니다. 로그인 페이지로 이동합니다.");
    router.push("/login");
  }

  const { data: callbackData, isLoading } = useGetGoogleCallbackData(code);
```

URLSearchParams를 사용해서 "code"가 몇번째에 위치하는지와 상관없이 해당하는 값을 파싱하도록 수정했고

이걸 사용하면 decodeURIComponent도 사용할 필요가 없어서 제거함

<br><br>


<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
